### PR TITLE
Conda - Pin python-pdal for now

### DIFF
--- a/iceroad_env.yaml
+++ b/iceroad_env.yaml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - python=3.9
-  - python-pdal
+  - python-pdal=3.3.0
   - gdal
   - rioxarray
   - py3dep


### PR DESCRIPTION
There is a warning message raised with the latest 3.4 version of python-pdal. Since this was not the used development version, I am pinning to an old version until the warning is resolved on the package end. Issue has been logged with the maintainer.