### PR TITLE
Conda - Pin PDAL to 2.6.2

### DIFF
--- a/iceroad_env.yaml
+++ b/iceroad_env.yaml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - python=3.9
   - python-pdal=3.3.0
+  - pdal=2.6.2
   - gdal
   - rioxarray
   - py3dep


### PR DESCRIPTION
Pinning the PDAL to the version run on Kelvin. PDAL has released new versions since the initial set up on the machine, but any version later than 2.6.2 is untested to date. This is part of troubleshooting the performance issues with Borah and ensuring the environments are identical.