### PR TITLE
Update iceroad_env.yaml

### DIFF
--- a/iceroad_env.yaml
+++ b/iceroad_env.yaml
@@ -1,7 +1,6 @@
 name: iceroad
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - python=3.9
   - python-pdal=3.3.0


### PR DESCRIPTION
the "defaults" package is not technically free any longer for research institutions.. See OIT's email on this.. This should not impact us because we already have a working conda environment. And for future builds, we just need to use "conda-forge" which is totally free.

https://www.theregister.com/2024/08/08/anaconda_puts_the_squeeze_on/ 